### PR TITLE
rename KernelModule to kernel::Module

### DIFF
--- a/rust_out_of_tree.rs
+++ b/rust_out_of_tree.rs
@@ -16,7 +16,7 @@ struct RustOutOfTree {
     message: String,
 }
 
-impl KernelModule for RustOutOfTree {
+impl kernel::Module for RustOutOfTree {
     fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust out-of-tree sample (init)\n");
 


### PR DESCRIPTION
KernelModule was renamed to Module in the linux repo: [rename KernelModule to Module](https://github.com/Rust-for-Linux/linux/pull/731/commits/4d90b2c5b6d5d4d837779eb0eebbd0e895e42209).