### PR TITLE
Adding support to generate rust-project.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.rmeta
 Module.symvers
 modules.order
+rust-project.json

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,10 @@ KDIR ?= /lib/modules/`uname -r`/build
 
 default:
 	$(MAKE) -C $(KDIR) M=$$PWD
+
+rust-analyzer:
+	$(MAKE) -C $(KDIR) rust-analyzer
+	$(Q) ./scripts/generate_rust_analyzer.py $(KDIR) `ls *.rs | head -n 1` > rust-project.json
+
+clean:
+	$(MAKE) -C $(KDIR) M=$$PWD clean

--- a/scripts/generate_rust_analyzer.py
+++ b/scripts/generate_rust_analyzer.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0
+"""generate_rust_analyzer - Generates an out-of-tree module `rust-project.json` file for `rust-analyzer`
+based on the kernel rust-project.json.
+"""
+
+import argparse
+import json
+import logging
+import os
+import pathlib
+import sys
+
+def generate_rust_project(kdir, root_module):
+    with open(kdir / "rust-project.json") as fd:
+        rust_project = json.loads(fd.read())
+
+    crate_indices = {}
+
+    for i, crate in enumerate(rust_project["crates"]):
+        crate_indices[crate["display_name"]] = i
+
+        # Prepend kdir to existing root_module
+        crate["root_module"] = os.path.join(kdir, crate["root_module"])
+        if crate.get("source"):
+            if "exclude_dirs" in crate["source"]:
+                crate["source"]["exclude_dirs"] = [
+                    os.path.join(kdir, e_dir) for e_dir in crate["source"]["exclude_dirs"]
+                ]
+            if "include_dirs" in crate["source"]:
+                crate["source"]["include_dirs"] = [
+                    os.path.join(kdir, i_dir) for i_dir in crate["source"]["include_dirs"]
+                ]
+
+    # Finally, append this module as a crate
+    rust_project["crates"].append({
+        "display_name": root_module.removesuffix(".rs"),
+        "root_module": root_module,
+        "is_workspace_member": False,
+        "is_proc_macro": False,
+        "deps": [
+            {"crate": index, "name": name}
+            for name, index in crate_indices.items()
+            if name == "kernel"
+        ],
+        "cfg": [],
+        "edition": "2021",
+        "env": {
+            "RUST_MODFILE": "This is only for rust-analyzer"
+        }
+    })
+    return rust_project
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--verbose', '-v', action='store_true')
+    parser.add_argument("kdir", type=pathlib.Path)
+    parser.add_argument("root_module", type=str)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="[%(asctime)s] [%(levelname)s] %(message)s",
+        level=logging.INFO if args.verbose else logging.WARNING
+    )
+
+    rust_project =  generate_rust_project(args.kdir, args.root_module)
+    json.dump(rust_project, sys.stdout, sort_keys=True, indent=4)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Using the [`linux/scripts/generate_rust_analyzer.py`](https://github.com/Rust-for-Linux/linux/blob/rust/scripts/generate_rust_analyzer.py) script as inspiration to add a `make rust-analyzer` target for an out-of-tree module.

Process:
- Make the `$KDIR` rust-project by issuing `make rust-analyzer`
- Extend the crates config with the out-of-tree module
- Write to `rust-project.json` in the module directory

Here's an example of the added module crate config:
```sh
$ more rust-project.json| tail -n 20
        {
            "cfg": [],
            "deps": [
                {
                    "crate": 6,
                    "name": "kernel"
                }
            ],
            "display_name": "rust_out_of_tree",
            "edition": "2021",
            "env": {
                "RUST_MODFILE": "This is only for rust-analyzer"
            },
            "is_proc_macro": false,
            "is_workspace_member": false,
            "root_module": "rust_out_of_tree.rs"
        }
    ],
    "sysroot_src": "/home/mat/.rustup/toolchains/1.62.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library"
}
```

And the updated `kernel` crate config (pointing at my KDIR of ../rust_for_linux):
```sh
more rust-project.json| jq 'del(.crates[].cfg) | .crates[]| select(.display_name=="kernel") '
{
  "deps": [
    {
      "crate": 0,
      "name": "core"
    },
    {
      "crate": 2,
      "name": "alloc"
    },
    {
      "crate": 3,
      "name": "macros"
    },
    {
      "crate": 4,
      "name": "build_error"
    },
    {
      "crate": 5,
      "name": "bindings"
    }
  ],
  "display_name": "kernel",
  "edition": "2021",
  "env": {
    "RUST_MODFILE": "This is only for rust-analyzer"
  },
  "is_proc_macro": false,
  "is_workspace_member": true,
  "root_module": "../rust_for_linux/rust/kernel/lib.rs",
  "source": {
    "exclude_dirs": [],
    "include_dirs": [
      "rust/kernel",
      "rust"
    ]
  }
}
```

===

One janky thing I'm not currently a fan of is getting the `root_module` and rust source file name. This script currently only supports one file/module. I'd prefer to get it from the Kbuild file by reading `obj-m` but I'm not sure how to do that, any suggestions here are welcome.