### PR TITLE
Fix build for Linux 6.1

### DIFF
--- a/rust_out_of_tree.rs
+++ b/rust_out_of_tree.rs
@@ -6,10 +6,10 @@ use kernel::prelude::*;
 
 module! {
     type: RustOutOfTree,
-    name: "rust_out_of_tree",
-    author: "Rust for Linux Contributors",
-    description: "Rust out-of-tree sample",
-    license: "GPL",
+    name: b"rust_out_of_tree",
+    author: b"Rust for Linux Contributors",
+    description: b"Rust out-of-tree sample",
+    license: b"GPL",
 }
 
 struct RustOutOfTree {
@@ -17,7 +17,7 @@ struct RustOutOfTree {
 }
 
 impl kernel::Module for RustOutOfTree {
-    fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
+    fn init(_module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust out-of-tree sample (init)\n");
 
         let mut numbers = Vec::new();


### PR DESCRIPTION
I tried building the kernel module for the Linux 6.1 kernel and these were the changes that were needed. I'm not sure if it makes sense to merge this, since it is probably due to changes in https://github.com/Rust-for-Linux/linux which were not yet up-streamed, but if anyone tries something similar this diff might be helpful.