### PR TITLE
Adding section about rust-analyzer in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.rmeta
 Module.symvers
 modules.order
+rust-project.json

--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ make[1]: Leaving directory '.../linux-with-rust-support'
 For details about the Rust support, see https://github.com/Rust-for-Linux/linux.
 
 For details about out-of-tree modules, see https://www.kernel.org/doc/html/latest/kbuild/modules.html.
+
+## rust-analyzer
+
+Rust for Linux supports building a `rust-project.json` configuration for [`rust-analyzer`](https://rust-analyzer.github.io/), including for out-of-tree modules:
+
+```sh
+make -C .../linux-with-rust-support M=`pwd` rust-analyzer
+```


### PR DESCRIPTION
Redo of PR #2 to just update docs & `.gitignore` with details for rust-analyzer & `rust-project.json`


Depends on https://github.com/Rust-for-Linux/linux/pull/914 for out-of-tree rust-analyzer support