### PR TITLE
Makefile: add modules_install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,6 @@ KDIR ?= /lib/modules/`uname -r`/build
 
 default:
 	$(MAKE) -C $(KDIR) M=$$PWD
+
+modules_install: default
+	$(MAKE) -C $(KDIR) M=$$PWD modules_install


### PR DESCRIPTION
Add a `modules_install` target to the Makefile to assist with installation of the built modules. This target is a useful shortcut for local development and is also used by build systems such as OpenEmbedded.