### PR TITLE
Update for late versions of Linux

### DIFF
--- a/rust_out_of_tree.rs
+++ b/rust_out_of_tree.rs
@@ -13,14 +13,14 @@ module! {
 }
 
 struct RustOutOfTree {
-    numbers: KVec<i32>,
+    numbers: Vec<i32>,
 }
 
 impl kernel::Module for RustOutOfTree {
     fn init(_module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust out-of-tree sample (init)\n");
 
-        let mut numbers = KVec::new();
+        let mut numbers = Vec::new();
         numbers.push(72, GFP_KERNEL)?;
         numbers.push(108, GFP_KERNEL)?;
         numbers.push(200, GFP_KERNEL)?;


### PR DESCRIPTION
In recent versions of Linux (not sure beginning from when) using `alloc:KVec` is no longer necessary and will throw error E0412.
Rename `KVec` to `Vec` solves this problem.