### PR TITLE
Makefile: add a "clean" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,6 @@ default:
 
 modules_install: default
 	$(MAKE) -C $(KDIR) M=$$PWD modules_install
+
+clean:
+	$(MAKE) -C $(KDIR) M=$$PWD clean


### PR DESCRIPTION
As for the other targets, just call the kernel build system to handle this.

Some integration tools (in my case Yocto) expect this target to exists.